### PR TITLE
Simplify serializeMixedToJson method to fix the bug

### DIFF
--- a/src/Utils/MixedJSONHandler.php
+++ b/src/Utils/MixedJSONHandler.php
@@ -39,12 +39,8 @@ class MixedJSONHandler implements SubscribingHandlerInterface
     /** @phpstan-ignore-next-line */
     public function serializeMixedToJson(JsonSerializationVisitor $visitor, mixed $any, array $type, Context $context): string
     {
-        $serializer = JSON::createSerializer();
-        $s = $serializer->serialize($any, 'json');
-        $s = ltrim($s, '"');
-        $s = rtrim($s, '"');
 
-        return $s;
+        return $any;
     }
 
     /** @phpstan-ignore-next-line */

--- a/src/Utils/MixedJSONHandler.php
+++ b/src/Utils/MixedJSONHandler.php
@@ -37,7 +37,7 @@ class MixedJSONHandler implements SubscribingHandlerInterface
     }
 
     /** @phpstan-ignore-next-line */
-    public function serializeMixedToJson(JsonSerializationVisitor $visitor, mixed $any, array $type, Context $context): string
+    public function serializeMixedToJson(JsonSerializationVisitor $visitor, mixed $any, array $type, Context $context): mixed
     {
 
         return $any;


### PR DESCRIPTION
Removed JSON serialization logic and returned the input directly.

Reference: [Slack conversation](https://novu.slack.com/archives/C075LU1MKPH/p1766150779487759?thread_ts=1766101652.007229&cid=C075LU1MKPH)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mixed-data handling now returns raw input values instead of JSON-serialized strings, changing the observable output format and improving fidelity for non-string payloads.

* **Style**
  * Minor formatting cleanup (end-of-file newline added).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->